### PR TITLE
Fix additionalProperties processing in codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 generate_models: generate_entities generate_metrics
 
 generate_entities:
-	datamodel-codegen --input ./opendatadiscovery-specification/specification/entities.yaml --output odd_models/models/models.py --input-file-type openapi --output-model-type pydantic_v2.BaseModel
+	datamodel-codegen --input ./opendatadiscovery-specification/specification/entities.yaml --output odd_models/models/models.py --input-file-type openapi --output-model-type pydantic_v2.BaseModel --allow-extra-fields
 generate_metrics:
 	datamodel-codegen --input ./opendatadiscovery-specification/specification/metrics.yaml --output odd_models/models/metrics.py --input-file-type openapi --output-model-type pydantic_v2.BaseModel
 generate_client:


### PR DESCRIPTION
Note: this will add
```
    model_config = ConfigDict(
        extra='allow',
    )
```
to the all generated classes!